### PR TITLE
Add class information to address tables for use with SWATCH

### DIFF
--- a/uGMT_algos/addr_table/cancel_out_mems.xml
+++ b/uGMT_algos/addr_table/cancel_out_mems.xml
@@ -1,11 +1,11 @@
 <node description="Collection of LUTs for cancel-out." fwinfo="endpoint">
-    <node id="cancel_out_mem_0" address="0x0" size="0x80" mode="block" description="Cancel-out LUT." fwinfo="endpoint;width=7"/>
-    <node id="cancel_out_mem_1" address="0x80" size="0x80" mode="block" description="Cancel-out LUT." fwinfo="endpoint;width=7"/>
-    <node id="cancel_out_mem_2" address="0x100" size="0x80" mode="block" description="Cancel-out LUT." fwinfo="endpoint;width=7"/>
-    <node id="cancel_out_mem_3" address="0x180" size="0x80" mode="block" description="Cancel-out LUT." fwinfo="endpoint;width=7"/>
-    <node id="cancel_out_mem_4" address="0x200" size="0x80" mode="block" description="Cancel-out LUT." fwinfo="endpoint;width=7"/>
-    <node id="cancel_out_mem_5" address="0x280" size="0x80" mode="block" description="Cancel-out LUT." fwinfo="endpoint;width=7"/>
-    <node id="cancel_out_mem_6" address="0x300" size="0x80" mode="block" description="Cancel-out LUT." fwinfo="endpoint;width=7"/>
-    <node id="cancel_out_mem_7" address="0x380" size="0x80" mode="block" description="Cancel-out LUT." fwinfo="endpoint;width=7"/>
-    <node id="cancel_out_mem_8" address="0x400" size="0x80" mode="block" description="Cancel-out LUT." fwinfo="endpoint;width=7"/>
+    <node id="cancel_out_mem_0" address="0x0" size="0x80" mode="block" description="Cancel-out LUT." fwinfo="endpoint;width=7" class="MuLUTNode"/>
+    <node id="cancel_out_mem_1" address="0x80" size="0x80" mode="block" description="Cancel-out LUT." fwinfo="endpoint;width=7" class="MuLUTNode"/>
+    <node id="cancel_out_mem_2" address="0x100" size="0x80" mode="block" description="Cancel-out LUT." fwinfo="endpoint;width=7" class="MuLUTNode"/>
+    <node id="cancel_out_mem_3" address="0x180" size="0x80" mode="block" description="Cancel-out LUT." fwinfo="endpoint;width=7" class="MuLUTNode"/>
+    <node id="cancel_out_mem_4" address="0x200" size="0x80" mode="block" description="Cancel-out LUT." fwinfo="endpoint;width=7" class="MuLUTNode"/>
+    <node id="cancel_out_mem_5" address="0x280" size="0x80" mode="block" description="Cancel-out LUT." fwinfo="endpoint;width=7" class="MuLUTNode"/>
+    <node id="cancel_out_mem_6" address="0x300" size="0x80" mode="block" description="Cancel-out LUT." fwinfo="endpoint;width=7" class="MuLUTNode"/>
+    <node id="cancel_out_mem_7" address="0x380" size="0x80" mode="block" description="Cancel-out LUT." fwinfo="endpoint;width=7" class="MuLUTNode"/>
+    <node id="cancel_out_mem_8" address="0x400" size="0x80" mode="block" description="Cancel-out LUT." fwinfo="endpoint;width=7" class="MuLUTNode"/>
 </node>

--- a/uGMT_algos/addr_table/mu_quad_deserialization.xml
+++ b/uGMT_algos/addr_table/mu_quad_deserialization.xml
@@ -1,9 +1,9 @@
 <!-- TODO: Set read-only flags. -->
-<node description="Mu deserializer regs and memories" fwinfo="endpoint">
-    <node id="sort_rank_mem_0" address="0x0" size="0x2000" mode="block" description="SortRank LUT for first channel." fwinfo="endpoint;width=13" />
-    <node id="sort_rank_mem_1" address="0x2000" size="0x2000" mode="block" description="SortRank LUT for second channel." fwinfo="endpoint;width=13" />
-    <node id="sort_rank_mem_2" address="0x4000" size="0x2000" mode="block" description="SortRank LUT for third channel." fwinfo="endpoint;width=13" />
-    <node id="sort_rank_mem_3" address="0x6000" size="0x2000" mode="block" description="SortRank LUT for fourth channel." fwinfo="endpoint;width=13" />
+<node description="Mu deserializer regs and memories" fwinfo="endpoint" class="MuQuadNode" parameters="content=rank_lut">
+    <node id="sort_rank_mem_0" address="0x0" size="0x2000" mode="block" description="SortRank LUT for first channel." fwinfo="endpoint;width=13" class="MuLUTNode" />
+    <node id="sort_rank_mem_1" address="0x2000" size="0x2000" mode="block" description="SortRank LUT for second channel." fwinfo="endpoint;width=13" class="MuLUTNode" />
+    <node id="sort_rank_mem_2" address="0x4000" size="0x2000" mode="block" description="SortRank LUT for third channel." fwinfo="endpoint;width=13" class="MuLUTNode" />
+    <node id="sort_rank_mem_3" address="0x6000" size="0x2000" mode="block" description="SortRank LUT for fourth channel." fwinfo="endpoint;width=13" class="MuLUTNode" />
     <node id="bc0_errors_0" address="0x8000" description="BC0 errors on channel 0." fwinfo="endpoint;width=0" />
     <node id="bc0_errors_1" address="0x8001" description="BC0 errors on channel 1." fwinfo="endpoint;width=0" />
     <node id="bc0_errors_2" address="0x8002" description="BC0 errors on channel 2." fwinfo="endpoint;width=0" />

--- a/uGMT_algos/addr_table/muon_counter_reset.xml
+++ b/uGMT_algos/addr_table/muon_counter_reset.xml
@@ -1,4 +1,4 @@
-<node description="Register to take manual control of muon counter reset signal." fwinfo="endpoint">
+<node description="Register to take manual control of muon counter reset signal." class="LumiCounterNode" fwinfo="endpoint">
   <node id="manual_reset_sel" address="0x0" description="Register to activate manual reset mode ('1' is enabled)." fwinfo="endpoint;width=0">
       <node id="enable_manual" mask="0x1" />
   </node>

--- a/uGMT_algos/addr_table/sorting.xml
+++ b/uGMT_algos/addr_table/sorting.xml
@@ -1,13 +1,13 @@
 <node description="Sorting and cancel-out algorithm LUTs" fwinfo="endpoint">
-  <node id="cou_bo_pos" address="0x0" module="file://cancel_out_bo.xml" description="LUTs containing match qualities for BMTF-OMTF matching on positive side."/>
-  <node id="cou_bo_neg" address="0x10000" module="file://cancel_out_bo.xml" description="LUTs containing match qualities for BMTF-OMTF matching on negative side."/>
-  <node id="cou_eo_pos" address="0x20000" module="file://cancel_out_eo.xml" description="LUTs containing match qualities for EMTF-OMTF matching on positive side."/>
-  <node id="cou_eo_neg" address="0x30000" module="file://cancel_out_eo.xml" description="LUTs containing match qualities for EMTF-OMTF matching on negative side."/>
-  <node id="cou_bmtf" address="0x40000" module="file://cancel_out_bmtf.xml" description="LUTs containing match qualities for matching within the BMTF region."/>
-  <node id="cou_omtf_pos" address="0x50000" module="file://cancel_out_half_sorters.xml" description="LUTs containing match qualities for matching within the OMTF region on positive side."/>
-  <node id="cou_omtf_neg" address="0x60000" module="file://cancel_out_half_sorters.xml" description="LUTs containing match qualities for matching within the OMTF region on negative side."/>
-  <node id="cou_emtf_pos" address="0x70000" module="file://cancel_out_half_sorters.xml" description="LUTs containing match qualities for matching within the EMTF region on positive side."/>
-  <node id="cou_emtf_neg" address="0x80000" module="file://cancel_out_half_sorters.xml" description="LUTs containing match qualities for matching within the EMTF region on negative side."/>
+  <node id="cou_bo_pos" address="0x0" module="file://cancel_out_bo.xml" description="LUTs containing match qualities for BMTF-OMTF matching on positive side." parameters="content=boPosMatchQualLUT" />
+  <node id="cou_bo_neg" address="0x10000" module="file://cancel_out_bo.xml" description="LUTs containing match qualities for BMTF-OMTF matching on negative side." parameters="content=boNegMatchQualLUT" />
+  <node id="cou_eo_pos" address="0x20000" module="file://cancel_out_eo.xml" description="LUTs containing match qualities for EMTF-OMTF matching on positive side." parameters="content=foPosMatchQualLUT" />
+  <node id="cou_eo_neg" address="0x30000" module="file://cancel_out_eo.xml" description="LUTs containing match qualities for EMTF-OMTF matching on negative side." parameters="content=foNegMatchQualLUT" />
+  <node id="cou_bmtf" address="0x40000" module="file://cancel_out_bmtf.xml" description="LUTs containing match qualities for matching within the BMTF region." parameters="content=brlSingleMatchQualLUT" />
+  <node id="cou_omtf_pos" address="0x50000" module="file://cancel_out_half_sorters.xml" description="LUTs containing match qualities for matching within the OMTF region on positive side." parameters="content=ovlPosSingleMatchQualLUT" />
+  <node id="cou_omtf_neg" address="0x60000" module="file://cancel_out_half_sorters.xml" description="LUTs containing match qualities for matching within the OMTF region on negative side." parameters="content=ovlNegSingleMatchQualLUT" />
+  <node id="cou_emtf_pos" address="0x70000" module="file://cancel_out_half_sorters.xml" description="LUTs containing match qualities for matching within the EMTF region on positive side." parameters="content=fwdPosSingleMatchQualLUT" />
+  <node id="cou_emtf_neg" address="0x80000" module="file://cancel_out_half_sorters.xml" description="LUTs containing match qualities for matching within the EMTF region on negative side." parameters="content=fwdNegSingleMatchQualLUT" />
   <node id="muon_counter_BMTF" address="0x90000" description="Counter for barrel sorter output" fwinfo="endpoint;width=0" />
   <node id="muon_counter_OMTFp" address="0x90001" description="Counter for positive overlap sorter output" fwinfo="endpoint;width=0" />
   <node id="muon_counter_OMTFn" address="0x90002" description="Counter for negative overlap sorter output" fwinfo="endpoint;width=0" />


### PR DESCRIPTION
Add class information to address tables for use with SWATCH

LUT name parameters in sorting.xml might need an update but I leave it like this for now since it works with the current implementation of the uGMT cell.