### PR TITLE
Address table changes to load LUTs from cell

### DIFF
--- a/uGMT_algos/addr_table/gen_calo_idx_bits.xml
+++ b/uGMT_algos/addr_table/gen_calo_idx_bits.xml
@@ -1,18 +1,18 @@
-<node description="LUTs for extrapolation and calo index bit generation at 120 MHz." fwinfo="endpoint">
-	<node id="eta_extrapolation_mem_0" address="0x0" size="0x2000" mode="block" description="Eta extrapolation LUT." fwinfo="endpoint;width=13" />
-    <node id="eta_extrapolation_mem_1" address="0x2000" size="0x2000" mode="block" description="Eta extrapolation LUT." fwinfo="endpoint;width=13" />
-    <node id="eta_extrapolation_mem_2" address="0x4000" size="0x2000" mode="block" description="Eta extrapolation LUT." fwinfo="endpoint;width=13" />
-    <node id="eta_extrapolation_mem_3" address="0x6000" size="0x2000" mode="block" description="Eta extrapolation LUT." fwinfo="endpoint;width=13" />
-	<node id="phi_extrapolation_mem_0" address="0x8000" size="0x4000" mode="block" description="Phi extrapolation LUT." fwinfo="endpoint;width=14" />
-    <node id="phi_extrapolation_mem_1" address="0xC000" size="0x4000" mode="block" description="Phi extrapolation LUT." fwinfo="endpoint;width=14" />
-    <node id="phi_extrapolation_mem_2" address="0x10000" size="0x4000" mode="block" description="Phi extrapolation LUT." fwinfo="endpoint;width=14" />
-    <node id="phi_extrapolation_mem_3" address="0x14000" size="0x4000" mode="block" description="Phi extrapolation LUT." fwinfo="endpoint;width=14" />
-	<node id="eta_idx_bits_mem_0" address="0x18000" size="0x200" mode="block" description="Eta index bit LUT." fwinfo="endpoint;width=9" />
-    <node id="eta_idx_bits_mem_1" address="0x18200" size="0x200" mode="block" description="Eta index bit LUT." fwinfo="endpoint;width=9" />
-    <node id="eta_idx_bits_mem_2" address="0x18400" size="0x200" mode="block" description="Eta index bit LUT." fwinfo="endpoint;width=9" />
-    <node id="eta_idx_bits_mem_3" address="0x18600" size="0x200" mode="block" description="Eta index bit LUT." fwinfo="endpoint;width=9" />
-	<node id="phi_idx_bits_mem_0" address="0x18800" size="0x400" mode="block" description="Phi index bit LUT." fwinfo="endpoint;width=10" />
-    <node id="phi_idx_bits_mem_1" address="0x18C00" size="0x400" mode="block" description="Phi index bit LUT." fwinfo="endpoint;width=10" />
-    <node id="phi_idx_bits_mem_2" address="0x19000" size="0x400" mode="block" description="Phi index bit LUT." fwinfo="endpoint;width=10" />
-    <node id="phi_idx_bits_mem_3" address="0x19400" size="0x400" mode="block" description="Phi index bit LUT." fwinfo="endpoint;width=10" />
+<node description="LUTs for extrapolation and calo index bit generation at 120 MHz." fwinfo="endpoint" >
+    <node id="eta_extrapolation_mem_0" address="0x0" size="0x1000" mode="block" description="Eta extrapolation LUT." fwinfo="endpoint;width=12" class="MuLUTNode" parameters="content=etaExtrapolation" />
+    <node id="eta_extrapolation_mem_1" address="0x2000" size="0x1000" mode="block" description="Eta extrapolation LUT." fwinfo="endpoint;width=12" class="MuLUTNode" parameters="content=etaExtrapolation" />
+    <node id="eta_extrapolation_mem_2" address="0x4000" size="0x1000" mode="block" description="Eta extrapolation LUT." fwinfo="endpoint;width=12" class="MuLUTNode" parameters="content=etaExtrapolation" />
+    <node id="eta_extrapolation_mem_3" address="0x6000" size="0x1000" mode="block" description="Eta extrapolation LUT." fwinfo="endpoint;width=12" class="MuLUTNode" parameters="content=etaExtrapolation" />
+    <node id="phi_extrapolation_mem_0" address="0x8000" size="0x1000" mode="block" description="Phi extrapolation LUT." fwinfo="endpoint;width=12" class="MuLUTNode" parameters="content=phiExtrapolation" />
+    <node id="phi_extrapolation_mem_1" address="0xC000" size="0x1000" mode="block" description="Phi extrapolation LUT." fwinfo="endpoint;width=12" class="MuLUTNode" parameters="content=phiExtrapolation" />
+    <node id="phi_extrapolation_mem_2" address="0x10000" size="0x1000" mode="block" description="Phi extrapolation LUT." fwinfo="endpoint;width=12" class="MuLUTNode" parameters="content=phiExtrapolation" />
+    <node id="phi_extrapolation_mem_3" address="0x14000" size="0x1000" mode="block" description="Phi extrapolation LUT." fwinfo="endpoint;width=12" class="MuLUTNode" parameters="content=phiExtrapolation" />
+    <node id="eta_idx_bits_mem_0" address="0x18000" size="0x200" mode="block" description="Eta index bit LUT." fwinfo="endpoint;width=9" class="MuLUTNode" parameters="content=IdxSelMemEta" />
+    <node id="eta_idx_bits_mem_1" address="0x18200" size="0x200" mode="block" description="Eta index bit LUT." fwinfo="endpoint;width=9" class="MuLUTNode" parameters="content=IdxSelMemEta" />
+    <node id="eta_idx_bits_mem_2" address="0x18400" size="0x200" mode="block" description="Eta index bit LUT." fwinfo="endpoint;width=9" class="MuLUTNode" parameters="content=IdxSelMemEta" />
+    <node id="eta_idx_bits_mem_3" address="0x18600" size="0x200" mode="block" description="Eta index bit LUT." fwinfo="endpoint;width=9" class="MuLUTNode" parameters="content=IdxSelMemEta" />
+    <node id="phi_idx_bits_mem_0" address="0x18800" size="0x400" mode="block" description="Phi index bit LUT." fwinfo="endpoint;width=10" class="MuLUTNode" parameters="content=IdxSelMemPhi" />
+    <node id="phi_idx_bits_mem_1" address="0x18C00" size="0x400" mode="block" description="Phi index bit LUT." fwinfo="endpoint;width=10" class="MuLUTNode" parameters="content=IdxSelMemPhi" />
+    <node id="phi_idx_bits_mem_2" address="0x19000" size="0x400" mode="block" description="Phi index bit LUT." fwinfo="endpoint;width=10" class="MuLUTNode" parameters="content=IdxSelMemPhi" />
+    <node id="phi_idx_bits_mem_3" address="0x19400" size="0x400" mode="block" description="Phi index bit LUT." fwinfo="endpoint;width=10" class="MuLUTNode" parameters="content=IdxSelMemPhi" />
 </node>

--- a/uGMT_algos/addr_table/isolation_assignment.xml
+++ b/uGMT_algos/addr_table/isolation_assignment.xml
@@ -1,4 +1,4 @@
 <node description="LUTs for the computation of isolation." fwinfo="endpoint">
-    <node id="abs_iso" module="file://isolation_mem_absolute.xml" address="0x0" description="Group of LUTs to compute the absolute isolation value."  />
-    <node id="rel_iso" module="file://isolation_mem_relative.xml" address="0x20000" description="Group of LUTs to compute the relative isolation."  />
+    <node id="abs_iso" module="file://isolation_mem_absolute.xml" address="0x0" description="Group of LUTs to compute the absolute isolation value." parameters="content=AbsIsoCheckMem" />
+    <node id="rel_iso" module="file://isolation_mem_relative.xml" address="0x20000" description="Group of LUTs to compute the relative isolation." parameters="content=RelIsoCheckMem" />
 </node>

--- a/uGMT_algos/addr_table/isolation_mem_absolute.xml
+++ b/uGMT_algos/addr_table/isolation_mem_absolute.xml
@@ -1,11 +1,11 @@
 <!-- TODO: More sensibly implemented as register? -->
 <node description="LUTs for the absolute computation of isolation." fwinfo="endpoint">
-    <node id="abs_iso_0" address="0x0" size="0x20" mode="block" description="Absolute isolation assigned to 1st muon." fwinfo="endpoint;width=5" />
-    <node id="abs_iso_1" address="0x20" size="0x20" mode="block" description="Absolute isolation assigned to 2nd muon." fwinfo="endpoint;width=5" />
-    <node id="abs_iso_2" address="0x40" size="0x20" mode="block" description="Absolute isolation assigned to 3rd muon." fwinfo="endpoint;width=5" />
-    <node id="abs_iso_3" address="0x60" size="0x20" mode="block" description="Absolute isolation assigned to 4th muon." fwinfo="endpoint;width=5" />
-    <node id="abs_iso_4" address="0x80" size="0x20" mode="block" description="Absolute isolation assigned to 5th muon." fwinfo="endpoint;width=5" />
-    <node id="abs_iso_5" address="0xA0" size="0x20" mode="block" description="Absolute isolation assigned to 6th muon." fwinfo="endpoint;width=5" />
-    <node id="abs_iso_6" address="0xC0" size="0x20" mode="block" description="Absolute isolation assigned to 7th muon." fwinfo="endpoint;width=5" />
-    <node id="abs_iso_7" address="0xE0" size="0x20" mode="block" description="Absolute isolation assigned to 8th muon." fwinfo="endpoint;width=5" />
+    <node id="abs_iso_mem_0" address="0x0" size="0x20" mode="block" description="Absolute isolation assigned to 1st muon." fwinfo="endpoint;width=5" class="MuLUTNode" />
+    <node id="abs_iso_mem_1" address="0x20" size="0x20" mode="block" description="Absolute isolation assigned to 2nd muon." fwinfo="endpoint;width=5" class="MuLUTNode" />
+    <node id="abs_iso_mem_2" address="0x40" size="0x20" mode="block" description="Absolute isolation assigned to 3rd muon." fwinfo="endpoint;width=5" class="MuLUTNode" />
+    <node id="abs_iso_mem_3" address="0x60" size="0x20" mode="block" description="Absolute isolation assigned to 4th muon." fwinfo="endpoint;width=5" class="MuLUTNode" />
+    <node id="abs_iso_mem_4" address="0x80" size="0x20" mode="block" description="Absolute isolation assigned to 5th muon." fwinfo="endpoint;width=5" class="MuLUTNode" />
+    <node id="abs_iso_mem_5" address="0xA0" size="0x20" mode="block" description="Absolute isolation assigned to 6th muon." fwinfo="endpoint;width=5" class="MuLUTNode" />
+    <node id="abs_iso_mem_6" address="0xC0" size="0x20" mode="block" description="Absolute isolation assigned to 7th muon." fwinfo="endpoint;width=5" class="MuLUTNode" />
+    <node id="abs_iso_mem_7" address="0xE0" size="0x20" mode="block" description="Absolute isolation assigned to 8th muon." fwinfo="endpoint;width=5" class="MuLUTNode" />
 </node>

--- a/uGMT_algos/addr_table/isolation_mem_relative.xml
+++ b/uGMT_algos/addr_table/isolation_mem_relative.xml
@@ -1,10 +1,10 @@
 <node description="LUTs for the relative computation of isolation." fwinfo="endpoint">
-    <node id="rel_iso_0" address="0x0" size="0x4000" mode="block" description="Absolute isolation assigned to 1st muon." fwinfo="endpoint;width=14" />
-    <node id="rel_iso_1" address="0x4000" size="0x4000" mode="block" description="Absolute isolation assigned to 2nd muon." fwinfo="endpoint;width=14" />
-    <node id="rel_iso_2" address="0x8000" size="0x4000" mode="block" description="Absolute isolation assigned to 3rd muon." fwinfo="endpoint;width=14" />
-    <node id="rel_iso_3" address="0xC000" size="0x4000" mode="block" description="Absolute isolation assigned to 4th muon." fwinfo="endpoint;width=14" />
-    <node id="rel_iso_4" address="0x10000" size="0x4000" mode="block" description="Absolute isolation assigned to 5th muon." fwinfo="endpoint;width=14" />
-    <node id="rel_iso_5" address="0x14000" size="0x4000" mode="block" description="Absolute isolation assigned to 6th muon." fwinfo="endpoint;width=14" />
-    <node id="rel_iso_6" address="0x18000" size="0x4000" mode="block" description="Absolute isolation assigned to 7th muon." fwinfo="endpoint;width=14" />
-    <node id="rel_iso_7" address="0x1C000" size="0x4000" mode="block" description="Absolute isolation assigned to 8th muon." fwinfo="endpoint;width=14" />
+    <node id="rel_iso_mem_0" address="0x0" size="0x4000" mode="block" description="Absolute isolation assigned to 1st muon." fwinfo="endpoint;width=14" class="MuLUTNode" />
+    <node id="rel_iso_mem_1" address="0x4000" size="0x4000" mode="block" description="Absolute isolation assigned to 2nd muon." fwinfo="endpoint;width=14" class="MuLUTNode" />
+    <node id="rel_iso_mem_2" address="0x8000" size="0x4000" mode="block" description="Absolute isolation assigned to 3rd muon." fwinfo="endpoint;width=14" class="MuLUTNode" />
+    <node id="rel_iso_mem_3" address="0xC000" size="0x4000" mode="block" description="Absolute isolation assigned to 4th muon." fwinfo="endpoint;width=14" class="MuLUTNode" />
+    <node id="rel_iso_mem_4" address="0x10000" size="0x4000" mode="block" description="Absolute isolation assigned to 5th muon." fwinfo="endpoint;width=14" class="MuLUTNode" />
+    <node id="rel_iso_mem_5" address="0x14000" size="0x4000" mode="block" description="Absolute isolation assigned to 6th muon." fwinfo="endpoint;width=14" class="MuLUTNode" />
+    <node id="rel_iso_mem_6" address="0x18000" size="0x4000" mode="block" description="Absolute isolation assigned to 7th muon." fwinfo="endpoint;width=14" class="MuLUTNode" />
+    <node id="rel_iso_mem_7" address="0x1C000" size="0x4000" mode="block" description="Absolute isolation assigned to 8th muon." fwinfo="endpoint;width=14" class="MuLUTNode" />
 </node>

--- a/uGMT_algos/addr_table/muon_input.xml
+++ b/uGMT_algos/addr_table/muon_input.xml
@@ -1,4 +1,4 @@
-<node description="LUTs and registers in input domain for uGMT" fwinfo="endpoint">
+<node description="LUTs and registers in input domain for uGMT" fwinfo="endpoint" parameters="content=quad_luts" >
     <node id="mu_quad_0" address="0x0" module="file://mu_quad_deserialization.xml" description="Contains sort rank LUT and phi offset register and well as error counters for positive EMTF inputs." />
     <node id="mu_quad_1" address="0x10000" module="file://mu_quad_deserialization.xml" description="Contains sort rank LUT and phi offset register and well as error counters for positive EMTF and OMTF inputs." />
     <node id="mu_quad_2" address="0x20000" module="file://mu_quad_deserialization.xml" description="Contains sort rank LUT and phi offset register and well as error counters for positive OMTF inputs." />


### PR DESCRIPTION
Some changes to the address table to load the LUTs from the DB.
Fix the width and size of the extrapolation LUTs